### PR TITLE
create notes relative to last release

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8560,12 +8560,19 @@ async function setStatus(pullRequest, state, description) {
 
 async function generatePatchNotes(pullRequest) {
   const tag = getTagName(pullRequest);
+  core.log("generating patchnotes");
 
   try {
     const latest_release = await client.rest.repos.getLatestRelease({
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
     });
+
+    core.log(
+      "Generating patch-notes relative to release " +
+        latest_release.tag_name +
+        ".."
+    );
 
     const response = await client.request(
       "POST /repos/{owner}/{repo}/releases/generate-notes",

--- a/dist/index.js
+++ b/dist/index.js
@@ -8568,9 +8568,6 @@ async function generatePatchNotes(pullRequest) {
       repo: github.context.repo.repo,
     });
 
-    core.info(latest_release);
-    core.info(JSON.stringify(latest_release));
-
     core.info(
       "Generating patch-notes relative to release " +
         latest_release.data.tag_name +
@@ -8584,7 +8581,7 @@ async function generatePatchNotes(pullRequest) {
         repo: github.context.repo.repo,
         tag_name: tag,
         target_commitish: pullRequest.head.ref,
-        previous_tag_name: latest_release.tag_name,
+        previous_tag_name: latest_release.data.tag_name,
       }
     );
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -8568,9 +8568,12 @@ async function generatePatchNotes(pullRequest) {
       repo: github.context.repo.repo,
     });
 
+    core.info(latest_release);
+    core.info(JSON.stringify(latest_release));
+
     core.info(
       "Generating patch-notes relative to release " +
-        latest_release.tag_name +
+        latest_release.data.tag_name +
         ".."
     );
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -8560,7 +8560,7 @@ async function setStatus(pullRequest, state, description) {
 
 async function generatePatchNotes(pullRequest) {
   const tag = getTagName(pullRequest);
-  core.log("generating patchnotes");
+  core.info("generating patchnotes");
 
   try {
     const latest_release = await client.rest.repos.getLatestRelease({
@@ -8568,7 +8568,7 @@ async function generatePatchNotes(pullRequest) {
       repo: github.context.repo.repo,
     });
 
-    core.log(
+    core.info(
       "Generating patch-notes relative to release " +
         latest_release.tag_name +
         ".."

--- a/src/action.js
+++ b/src/action.js
@@ -289,7 +289,9 @@ async function generatePatchNotes(pullRequest) {
       repo: github.context.repo.repo,
     });
 
-    core.debug(latest_release.tag_name);
+    core.log(
+      "Generating patch-notes relative to release " + latest_release.tag_name
+    );
 
     const response = await client.request(
       "POST /repos/{owner}/{repo}/releases/generate-notes",

--- a/src/action.js
+++ b/src/action.js
@@ -290,9 +290,12 @@ async function generatePatchNotes(pullRequest) {
       repo: github.context.repo.repo,
     });
 
+    core.info(latest_release);
+    core.info(JSON.stringify(latest_release));
+
     core.info(
       "Generating patch-notes relative to release " +
-        latest_release.tag_name +
+        latest_release.data.tag_name +
         ".."
     );
 

--- a/src/action.js
+++ b/src/action.js
@@ -290,9 +290,6 @@ async function generatePatchNotes(pullRequest) {
       repo: github.context.repo.repo,
     });
 
-    core.info(latest_release);
-    core.info(JSON.stringify(latest_release));
-
     core.info(
       "Generating patch-notes relative to release " +
         latest_release.data.tag_name +
@@ -306,7 +303,7 @@ async function generatePatchNotes(pullRequest) {
         repo: github.context.repo.repo,
         tag_name: tag,
         target_commitish: pullRequest.head.ref,
-        previous_tag_name: latest_release.tag_name,
+        previous_tag_name: latest_release.data.tag_name,
       }
     );
 

--- a/src/action.js
+++ b/src/action.js
@@ -282,7 +282,7 @@ async function setStatus(pullRequest, state, description) {
 
 async function generatePatchNotes(pullRequest) {
   const tag = getTagName(pullRequest);
-  core.log("generating patchnotes");
+  core.info("generating patchnotes");
 
   try {
     const latest_release = await client.rest.repos.getLatestRelease({
@@ -290,7 +290,7 @@ async function generatePatchNotes(pullRequest) {
       repo: github.context.repo.repo,
     });
 
-    core.log(
+    core.info(
       "Generating patch-notes relative to release " +
         latest_release.tag_name +
         ".."

--- a/src/action.js
+++ b/src/action.js
@@ -289,6 +289,8 @@ async function generatePatchNotes(pullRequest) {
       repo: github.context.repo.repo,
     });
 
+    core.debug(latest_release.tag_name);
+
     const response = await client.request(
       "POST /repos/{owner}/{repo}/releases/generate-notes",
       {

--- a/src/action.js
+++ b/src/action.js
@@ -282,6 +282,7 @@ async function setStatus(pullRequest, state, description) {
 
 async function generatePatchNotes(pullRequest) {
   const tag = getTagName(pullRequest);
+  core.log("generating patchnotes");
 
   try {
     const latest_release = await client.rest.repos.getLatestRelease({
@@ -290,7 +291,9 @@ async function generatePatchNotes(pullRequest) {
     });
 
     core.log(
-      "Generating patch-notes relative to release " + latest_release.tag_name
+      "Generating patch-notes relative to release " +
+        latest_release.tag_name +
+        ".."
     );
 
     const response = await client.request(


### PR DESCRIPTION
The documentation says this is default, but it apparently isn't. It would instead create relative to first release each time, which is awful. This skips drafts and pre-releases as well.