### PR TITLE
handle edge-case of no previous release

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8560,7 +8560,6 @@ async function setStatus(pullRequest, state, description) {
 
 async function generateReleaseNotes(pullRequest) {
   const tag = getTagName(pullRequest);
-  core.info("generating releasenotes");
 
   var previous_tag_name;
   try {
@@ -8569,15 +8568,15 @@ async function generateReleaseNotes(pullRequest) {
       repo: github.context.repo.repo,
     });
     previous_tag_name = latest_release.data.tag_name;
-  } catch (error) {
-    previous_tag_name = "";
-  }
-
-  try {
     core.info(
       "Generating release-notes relative to release " + previous_tag_name + ".."
     );
+  } catch (error) {
+    previous_tag_name = "";
+    core.info("Generating release-notes relative to start of repository..");
+  }
 
+  try {
     const response = await client.request(
       "POST /repos/{owner}/{repo}/releases/generate-notes",
       {

--- a/dist/index.js
+++ b/dist/index.js
@@ -8562,16 +8562,20 @@ async function generateReleaseNotes(pullRequest) {
   const tag = getTagName(pullRequest);
   core.info("generating releasenotes");
 
+  var previous_tag_name;
   try {
     const latest_release = await client.rest.repos.getLatestRelease({
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
     });
+    previous_tag_name = latest_release.data.tag_name;
+  } catch (error) {
+    previous_tag_name = "";
+  }
 
+  try {
     core.info(
-      "Generating release-notes relative to release " +
-        latest_release.data.tag_name +
-        ".."
+      "Generating release-notes relative to release " + previous_tag_name + ".."
     );
 
     const response = await client.request(
@@ -8581,7 +8585,7 @@ async function generateReleaseNotes(pullRequest) {
         repo: github.context.repo.repo,
         tag_name: tag,
         target_commitish: pullRequest.head.ref,
-        previous_tag_name: latest_release.data.tag_name,
+        previous_tag_name: previous_tag_name,
       }
     );
 

--- a/src/action.js
+++ b/src/action.js
@@ -284,16 +284,20 @@ async function generateReleaseNotes(pullRequest) {
   const tag = getTagName(pullRequest);
   core.info("generating releasenotes");
 
+  var previous_tag_name;
   try {
     const latest_release = await client.rest.repos.getLatestRelease({
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
     });
+    previous_tag_name = latest_release.data.tag_name;
+  } catch (error) {
+    previous_tag_name = "";
+  }
 
+  try {
     core.info(
-      "Generating release-notes relative to release " +
-        latest_release.data.tag_name +
-        ".."
+      "Generating release-notes relative to release " + previous_tag_name + ".."
     );
 
     const response = await client.request(
@@ -303,7 +307,7 @@ async function generateReleaseNotes(pullRequest) {
         repo: github.context.repo.repo,
         tag_name: tag,
         target_commitish: pullRequest.head.ref,
-        previous_tag_name: latest_release.data.tag_name,
+        previous_tag_name: previous_tag_name,
       }
     );
 

--- a/src/action.js
+++ b/src/action.js
@@ -282,7 +282,6 @@ async function setStatus(pullRequest, state, description) {
 
 async function generateReleaseNotes(pullRequest) {
   const tag = getTagName(pullRequest);
-  core.info("generating releasenotes");
 
   var previous_tag_name;
   try {
@@ -291,15 +290,15 @@ async function generateReleaseNotes(pullRequest) {
       repo: github.context.repo.repo,
     });
     previous_tag_name = latest_release.data.tag_name;
-  } catch (error) {
-    previous_tag_name = "";
-  }
-
-  try {
     core.info(
       "Generating release-notes relative to release " + previous_tag_name + ".."
     );
+  } catch (error) {
+    previous_tag_name = "";
+    core.info("Generating release-notes relative to start of repository..");
+  }
 
+  try {
     const response = await client.request(
       "POST /repos/{owner}/{repo}/releases/generate-notes",
       {

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -408,7 +408,5 @@ test("generateReleaseNotes", async () => {
     .reply(200, '{"name": "flufftitle","body": "mybody"}')
     .get(`/repos/${owner}/${repo}/releases/latest`)
     .reply(404);
-  await expect(generateReleaseNotes(pr)).rejects.toThrow(
-    /Failed to generate a body/
-  );
+  await generateReleaseNotes(pr);
 });


### PR DESCRIPTION
Forgot that a valid reason for not returning a previous release is... there is none, this is the first one. I now handle that.